### PR TITLE
Changing the OS Type to Ubuntu_64

### DIFF
--- a/definitions/heroku/definition.rb
+++ b/definitions/heroku/definition.rb
@@ -1,7 +1,7 @@
 Veewee::Session.declare({
   :cpu_count => '1', :memory_size=> '512',
   :disk_size => '10140', :disk_format => 'VDI', :hostiocache => 'off',
-  :os_type_id => 'Ubuntu',
+  :os_type_id => 'Ubuntu_64',
   :iso_file => "ubuntu-10.04.4-server-amd64.iso",
   :iso_src => "http://releases.ubuntu.com/lucid/ubuntu-10.04.4-server-amd64.iso",
   :iso_md5 => "9b218654cdcdf9722171648c52f8a088",


### PR DESCRIPTION
Fixing a error that occurs with the original Mac Pro. After booting I would always receive the following error.

kernel requires an x86_64 cpu, but only detected an i686 cpu
unable to boot - please use a kernel appropriate for your cpu

Changing the OS Type ID fixed the issue.
