### PR TITLE
Added python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ the Celadon Cedar stack.
 * Ubuntu 10.04 64bit
 * Ruby 1.9.2-p290 MRI
 * RubyGems 1.3.7
+* Python with pip, virtualenv, and virtualenvwrapper
 * PostgreSQL 9.1.5
 * NodeJS 0.4.7
+* Foreman https://github.com/ddollar/foreman
 
 ## Gotchas
 

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -48,6 +48,9 @@ rm -rf rubygems-1.3.7*
 /opt/ruby/bin/gem install puppet --no-ri --no-rdoc
 /opt/ruby/bin/gem install bundler --no-ri --no-rdoc
 
+# Install Foreman
+/opt/ruby/bin/gem install foreman --no-ri --no-rdoc
+
 # Install pip, virtualenv, and virtualenvwrapper
 easy_install pip
 pip install virtualenv
@@ -56,9 +59,6 @@ pip install virtualenvwrapper
 # Add a basic virtualenvwrapper config to .bashrc
 echo "export WORKON_HOME=/home/vagrant/.virtualenvs" >> /home/vagrant/.bashrc
 echo "source /usr/local/bin/virtualenvwrapper.sh" >> /home/vagrant/.bashrc
-
-# Install Foreman
-/opt/ruby/bin/gem install foreman --no-ri --no-rdoc
 
 # Install PostgreSQL 9.1.5
 wget http://ftp.postgresql.org/pub/source/v9.1.5/postgresql-9.1.5.tar.gz

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -10,6 +10,10 @@ apt-get -y install linux-headers-$(uname -r) build-essential
 apt-get -y install zlib1g-dev libssl-dev libreadline5-dev
 apt-get -y install git-core vim
 
+# Apt-install python tools and libraries
+# libpq-dev lets us compile psycopg for Postgres
+apt-get -y install python-setuptools python-dev libpq-dev pep8
+
 # Setup sudo to allow no-password sudo for "admin"
 cp /etc/sudoers /etc/sudoers.orig
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
@@ -43,6 +47,18 @@ rm -rf rubygems-1.3.7*
 /opt/ruby/bin/gem install chef --no-ri --no-rdoc
 /opt/ruby/bin/gem install puppet --no-ri --no-rdoc
 /opt/ruby/bin/gem install bundler --no-ri --no-rdoc
+
+# Install pip, virtualenv, and virtualenvwrapper
+easy_install pip
+pip install virtualenv
+pip install virtualenvwrapper
+
+# Add a basic virtualenvwrapper config to .bashrc
+echo "export WORKON_HOME=/home/vagrant/.virtualenvs" >> /home/vagrant/.bashrc
+echo "source /usr/local/bin/virtualenvwrapper.sh" >> /home/vagrant/.bashrc
+
+# Install Foreman
+/opt/ruby/bin/gem install foreman --no-ri --no-rdoc
 
 # Install PostgreSQL 9.1.5
 wget http://ftp.postgresql.org/pub/source/v9.1.5/postgresql-9.1.5.tar.gz


### PR DESCRIPTION
Hello. I'm quite a fan of what you've done here as I'm also a fan of Vagrant and Heroku.

However, my weapons of choice are Python and Django and I found the default build was missing some parts. So, I've tried to help fix that.

Specifically, I've added a few bits to the postinstall script to include python setup and dev tools as well as virtualenv and a rather minimal configuration to make all of that work out of the box for python devs.

I've also included Foreman to make the VM work even more like Heroku, in that it respects a project's Procfile and .env configuration

I've done a little bit of testing locally, it seems to work pretty well out of the box. I hope this will make the VM even that much better.
