### PR TITLE
Add a "vagrant" user to Postgres.

### DIFF
--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -78,6 +78,9 @@ su -c "/usr/bin/initdb -D /var/pgsql/data --locale=en_US.UTF-8 --encoding=UNICOD
 mkdir /var/pgsql/data/log
 chown postgres /var/pgsql/data/log
 
+# Add 'vagrant' role
+su -c 'createuser vagrant -s' postgres
+
 # Start postgres
 su -c '/usr/bin/pg_ctl start -l /var/pgsql/data/log/logfile -D /var/pgsql/data' postgres
 


### PR DESCRIPTION
I didn't write this, @greggroth did, but I usually end up doing something similar. It allows the vagrant user to connect to the Postgres database without any username and password.
