### PR TITLE
Fix for bundle commands displaying a deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'vagrant', '~> 1.0.5'
 gem 'veewee', '~> 0.3.0.beta1'


### PR DESCRIPTION
The symbol `:rubygems` is deprecated and will display a warning. This commit will reference the recommend `https://rubygems.org` to fix the warning.
