### PR TITLE
Don't download guest additions, Vagrant does that for us

### DIFF
--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -115,8 +115,7 @@ chown -R vagrant /home/vagrant/.ssh
 
 # Installing the virtualbox guest additions
 VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
-cd /tmp
-wget http://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso
+cd /home/vagrant
 mount -o loop VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run
 umount /mnt


### PR DESCRIPTION
It seems that Vagrant 1.2 (haven't tried any previous versions) downloads guest additions automatically ... or maybe it's Veewee. Either way, they get put in the iso/ folder and appear in /home/vagrant so we can just use them from there instead of downloading them yet again to /tmp. Trying to speed up the full build however I can here.
