### PR TITLE
Build all the PostgreSQL extensions.

### DIFF
--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -68,7 +68,7 @@ wget http://ftp.postgresql.org/pub/source/v9.2.4/postgresql-9.2.4.tar.bz2
 tar jxf postgresql-9.2.4.tar.bz2
 cd postgresql-9.2.4
 ./configure --prefix=/usr
-make
+make world
 make install
 cd ..
 rm -rf postgresql-9.2.4*


### PR DESCRIPTION
I needed the hstore extension and discovered that PostgreSQL's default make target doesn't build any of the contrib extensions, but the "world" is supposed to.
