### PR TITLE
Changed git clone URL to the public HTTPS one

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And run `vagrant up`. The box will be downloaded and imported for you.
 First, clone the repo and install gems with bundler.
 
 ```bash
-$ git clone git@github.com:ejholmes/vagrant-heroku.git
+$ git clone https://github.com/ejholmes/vagrant-heroku.git
 $ cd vagrant-heroku
 $ bundle install
 ```


### PR DESCRIPTION
The git URL here is the R/W one, which will work for actual project contributors, but sadly not for anybody else. Switched to the read-only version that'll work for everybody.
