### PR TITLE
#31 Use Node.js 0.10.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,91 @@ the Celadon Cedar stack.
 * PostgreSQL 9.2.4
 * NodeJS 0.4.7
 * Foreman https://github.com/ddollar/foreman
+
+# Dave's tips:
+
+## Postgres
+
+All Postgres stuff is installed as the `postgres` user, in to `/var/pgsql/` (see [here](https://github.com/dukedave/vagrant-heroku/blob/cfe14b102c306c358e8b63b52b2330edb1c2bca6/definitions/heroku/postinstall.sh#L66)).
+
+To connect from host use: `$ psql -h localhost -p 3432 vagrant vagrant`, that's *connect to the forwarded port on localhost, to a DB called vagrant, as a user (role) called vagrant*.
+
+To restart Postgres:
+
+1. `vagrant ssh` on to the box
+1. `sudo su` to become root
+1. `sudo -u postgres pg_ctl -D /var/pgsql/data/ restart`, this (as user `postgres`) tells `pg_ctl` to restart the DB at `/var/pgsql/data/`.
+
+# Setup 
+
+## Console
+
+In `~/.bashrc`:
+
+```
+set -o vi
+set editing-mode vi
+cd /vagrant
+```
+
+In `~/.inputrc`:
+
+```
+set editing-mode vi
+```
+
+In `~/.editrc`:
+
+```
+bind -v
+```
+
+In `~/.irbrc`:
+
+```
+require 'irb/completion'
+IRB.conf[:PROMPT_MODE] = :SIMPLE
+
+require 'irb/ext/save-history'
+ARGV.concat [ "--readline", "--prompt-mode", "simple" ]
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = "#{ENV['HOME']}/.irb-save-history" 
+```
+
+## Postgres
+
+* Add port forward to `Vagrantfile`:
+  `config.vm.network :forwarded_port, guest: 5432, host: 3432`
+  (I chose `3432` to stick with the convention of having Vagrant's forwarded ports in the 3000s).
+
+* Need to change listen address in `/var/pgsql/data/postgresql.conf` to find remote connection:
+  `listen_addresses = '*'`.
+
+* Need to change `IPv4` permissions in `/var/pgsql/data/pg_hba.conf` to allow remote connection:
+
+  `host    all             all             all                     trust`
+
+* Find `ERROR REPORTING AND LOGGING` in `/var/pgsql/data/postgresql.conf` and set:
+
+  `log_destination = 'stderr'` and `logging_collector = on`
+
+* When starting Unicorn from a fresh box you may see:
+
+      ERROR -- : FATAL:  role "vagrant" does not exist
+
+  Fix it with `sudo su` then `su -c 'createuser vagrant -s' postgres`.
+
+
+## Redis
+
+* Grab bz2 from [here](http://redis.io/download), `make`, `sudo make install`, then `./utils/install_server.sh` and follow instructions.
+
+* Add port forward to `Vagrantfile`:
+  `  config.vm.network :forwarded_port, guest: 6379, host: 3379`
+  (I chose `3379` to stick with the convention of having Vagrant's forwarded ports in the 3000s).
+
+* Change `bind` address per [this answer](http://stackoverflow.com/a/13928537/21115) and remember to restart Redis.
+
+## Bundler
+
+Tell bundler to prefer local gem git repos for `prop_store` and `places` with [a local override](http://stackoverflow.com/a/14167368/21115), e.g:

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -81,6 +81,10 @@ su -c "/usr/bin/initdb -D /var/pgsql/data --locale=en_US.UTF-8 --encoding=UNICOD
 mkdir /var/pgsql/data/log
 chown postgres /var/pgsql/data/log
 
+# Allow connection from host machine
+su -c "echo \"listen_addresses = '*'\" >> /var/pgsql/data/postgresql.conf" postgres
+su -c "sed -i \"s/127.0.0.1\/32/all/\" /var/pgsql/data/pg_hba.conf" postgres
+
 # Start postgres
 su -c '/usr/bin/pg_ctl start -l /var/pgsql/data/log/logfile -D /var/pgsql/data' postgres
 

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -91,7 +91,7 @@ echo "su -c '/usr/bin/pg_ctl start -l /var/pgsql/data/log/logfile -D /var/pgsql/
 # Install NodeJs for a JavaScript runtime
 git clone https://github.com/joyent/node.git
 cd node
-git checkout v0.4.7
+git checkout v0.10.26
 ./configure --prefix=/usr
 make
 make install

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -98,6 +98,9 @@ make install
 cd ..
 rm -rf node*
 
+# Install Redis
+apt-get install -y redis-server
+
 # Add /opt/ruby/bin to the global path as the last resort so
 # Ruby, RubyGems, and Chef/Puppet are visible
 echo 'PATH=$PATH:/opt/ruby/bin' > /etc/profile.d/vagrantruby.sh

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -67,7 +67,7 @@ echo "source /usr/local/bin/virtualenvwrapper.sh" >> /home/vagrant/.bashrc
 wget http://ftp.postgresql.org/pub/source/v9.3.3/postgresql-9.3.3.tar.bz2
 tar jxf postgresql-9.3.3.tar.bz2
 cd postgresql-9.3.3
-./configure --prefix=/usr
+./configure --prefix=/usr --with-openssl
 make world
 make install-world
 cd ..

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -63,15 +63,15 @@ pip install virtualenvwrapper
 echo "export WORKON_HOME=/home/vagrant/.virtualenvs" >> /home/vagrant/.bashrc
 echo "source /usr/local/bin/virtualenvwrapper.sh" >> /home/vagrant/.bashrc
 
-# Install PostgreSQL 9.2.4
-wget http://ftp.postgresql.org/pub/source/v9.2.4/postgresql-9.2.4.tar.bz2
-tar jxf postgresql-9.2.4.tar.bz2
-cd postgresql-9.2.4
+# Install PostgreSQL 9.3.3
+wget http://ftp.postgresql.org/pub/source/v9.3.3/postgresql-9.3.3.tar.bz2
+tar jxf postgresql-9.3.3.tar.bz2
+cd postgresql-9.3.3
 ./configure --prefix=/usr
 make world
 make install-world
 cd ..
-rm -rf postgresql-9.2.4*
+rm -rf postgresql-9.3.3*
 
 # Initialize postgres DB
 useradd -p postgres postgres

--- a/definitions/heroku/preseed.cfg
+++ b/definitions/heroku/preseed.cfg
@@ -1,7 +1,6 @@
 ## Options to set on the command line
 d-i debian-installer/locale string en_US.UTF-8
 d-i console-setup/ask_detect boolean false
-d-i console-setup/layout string Belgium
 
 #d-i netcfg/get_hostname string dummy
 d-i netcfg/get_hostname string unassigned-hostname
@@ -11,11 +10,9 @@ d-i netcfg/get_domain string unassigned-domain
 # Not working , specify a dummy in the DHCP
 #d-i netcfg/no_default_route boolean
 
-d-i time/zone string Europe/Brussels
+d-i time/zone string UTC
 d-i clock-setup/utc-auto boolean true
 d-i clock-setup/utc boolean true
-
-d-i kbd-chooser/method	select	Belgian
 
 d-i netcfg/wireless_wep string
 


### PR DESCRIPTION
From the [Heroku docs](https://devcenter.heroku.com/articles/getting-started-with-nodejs):

> Lastly, you should specify the version(s) of node that are compatible with your application by adding an engines field to your package.json. If you choose not to set this value, the default stable version of node will always be used when you deploy.

Parsing `package.json` is a bit outside the scope of this project, so I opted to just let it default.
We can see [here](https://github.com/heroku/heroku-buildpack-nodejs/blob/master/bin/compile#L24) how the Heroku Node.js buildpack uses semver.io to resolve which version to install, and [with a blank version range](https://semver.io/node/resolve?range=) you currently get `0.10.26`, so that's what I opted to use here.

I [built from scratch](https://github.com/ejholmes/vagrant-heroku#building-from-scratch) and it seems to work just fine!
