### PR TITLE
Include libyaml-develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 /.bundle
 /bin
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,4 @@
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "heroku"
+end

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -7,8 +7,9 @@ date > /etc/vagrant_box_build_time
 apt-get -y update
 apt-get -y upgrade
 apt-get -y install linux-headers-$(uname -r) build-essential
-apt-get -y install zlib1g-dev libssl-dev libreadline5-dev libyaml-dev
+apt-get -y install zlib1g-dev libssl-dev libreadline5-dev
 apt-get -y install git-core vim
+apt-get -y install  libyaml-dev
 
 # Apt-install python tools and libraries
 # libpq-dev lets us compile psycopg for Postgres

--- a/definitions/heroku/postinstall.sh
+++ b/definitions/heroku/postinstall.sh
@@ -7,7 +7,7 @@ date > /etc/vagrant_box_build_time
 apt-get -y update
 apt-get -y upgrade
 apt-get -y install linux-headers-$(uname -r) build-essential
-apt-get -y install zlib1g-dev libssl-dev libreadline5-dev
+apt-get -y install zlib1g-dev libssl-dev libreadline5-dev libyaml-dev
 apt-get -y install git-core vim
 
 # Apt-install python tools and libraries


### PR DESCRIPTION
This PR includes installation of libyaml-dev, which includes the header files required for installing the psych gem. Sites that run fine of heroku-cedar fail to run on the previous Vagrant box because of the lack of these files.

Additionally includes a simple vagrant file that allows the box to be launched for installation verfication.
